### PR TITLE
Add possibility to pass separate contexts for multiple recipients

### DIFF
--- a/Service/ExtraMailer.php
+++ b/Service/ExtraMailer.php
@@ -2,6 +2,8 @@
 
 namespace EE\ExtraMailerBundle\Service;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 class ExtraMailer
 {
 
@@ -14,16 +16,16 @@ class ExtraMailer
      */
     protected $twig;
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     * @var ContainerInterface
      */
     protected $container;
 
     /**
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-     * @param \Swift_Mailer $mailer
-     * @param \Twig_Environment $twig
+     * @param ContainerInterface $container
+     * @param \Swift_Mailer      $mailer
+     * @param \Twig_Environment  $twig
      */
-    public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, \Swift_Mailer $mailer, \Twig_Environment $twig)
+    public function __construct(ContainerInterface $container, \Swift_Mailer $mailer, \Twig_Environment $twig)
     {
         $this->container    = $container;
         $this->mailer       = $mailer;
@@ -31,30 +33,125 @@ class ExtraMailer
     }
 
     /**
-     * @param array $toEmail
-     * @param string $templateName
+     * @param array $recipients one or more, 'email' => 'name'
+     * @param       $templateName
+     * @param array $context Values to be used during template rendering passed as 'templateVarName' => value
+     *                       Can be either one-dimensional in which case all recipients will receive identical messages
+     *                       or two-dimensional. In the latter case number of 2nd dimension arrays must match number of
+     *                       recipients and each recipient will receive a message according to given variables
+     * @param array $options
+     *
+     * @return int Number of sent emails
+     */
+
+    public function sendMessage(Array $recipients, $templateName, $context = array(), $options = array())
+    {
+        $queuedMessages = $this->composeMessages($recipients, $templateName, $context, $options);
+
+        $count = 0;
+        foreach($queuedMessages as $message) {
+            $count += $this->mailer->send($message);
+        }
+        return $count;
+
+    }
+
+    /**
+     * @see ExtraMailer::sendMessage
+     *
+     * @param array $recipients
+     * @param       $templateName
      * @param array $context
      * @param array $options
-     * @return bool
+     *
+     * @return array
+     * @throws \LogicException
+     *
+     * @todo remove duplicated code
      */
-    public function sendMessage(Array $toEmail, $templateName, $context = array(), $options = array())
+    public function composeMessages(Array $recipients, $templateName, $context = array(), $options = array())
     {
-        $template = $this->twig->loadTemplate($templateName);
+        $queuedMessages = array();
+
+        if (isset($context[0]) && is_array($context[0])) {
+
+            if (count($context) !== count($recipients)) {
+                throw new \LogicException('in multicontext mode number of recipients must match number of contexts');
+            }
+
+            $orderedRecipients = array();
+            foreach($recipients as $email => $name) {
+                $orderedRecipients[] = array($email => $name);
+            }
+
+            $template = $this->twig->loadTemplate($templateName);
+
+            for ($i = 0; $i < count($recipients); $i++) {
+                $subject = $this->getRenderedSubject($template, $context[$i]);
+
+                $message = $this->prepareMessage()
+                    ->setSubject($subject)
+                    ->setTo($orderedRecipients[$i]);
+
+                $message = $this->prepareContent($message, $template, $context[$i]);
+
+                if (array_key_exists('attachments', $options)) {
+                    $message = $this->attach($message, $options['attachments']);
+                }
+
+                $queuedMessages[] = $message;
+            }
+
+        } else {
+            $template = $this->twig->loadTemplate($templateName);
+
+            $subject = $this->getRenderedSubject($template, $context);
+
+            $message = $this->prepareMessage()
+                ->setSubject($subject)
+                ->setTo($recipients);
+
+            $message = $this->prepareContent($message, $template, $context);
+
+
+            if (array_key_exists('attachments', $options)) {
+                $message = $this->attach($message, $options['attachments']);
+            }
+
+            $queuedMessages[] = $message;
+        }
+
+        return $queuedMessages;
+    }
+
+    /**
+     * @return \Swift_Message
+     */
+    public function prepareMessage()
+    {
+        return \Swift_Message::newInstance()
+            ->setFrom(
+                $this->container->getParameter('ee_extra_mailer.from_email.address'),
+                $this->container->getParameter('ee_extra_mailer.from_email.sender_name')
+            );
+    }
+
+    /**
+     * @param \Swift_Message $message
+     * @param                $template
+     * @param array          $context
+     *
+     * @return \Swift_Message
+     */
+    public function prepareContent(\Swift_Message $message, $template, array $context)
+    {
 
         $layoutTxt  = $this->twig->loadTemplate('EEExtraMailerBundle::layout.txt.twig');
         $layoutHtml = $this->twig->loadTemplate('EEExtraMailerBundle::layout.html.twig');
 
-        $subject  = $template->renderBlock('subject', $context);
-        $bodyText = $template->renderBlock('body_text', $context);
-        $bodyHtml = $template->renderBlock('body_html', $context);
-
-        $message = \Swift_Message::newInstance()
-            ->setSubject($subject)
-            ->setFrom(
-                $this->container->getParameter('ee_extra_mailer.from_email.address'),
-                $this->container->getParameter('ee_extra_mailer.from_email.sender_name')
-            )
-            ->setTo($toEmail);
+        $subject = $this->getRenderedSubject($template, $context);
+        $bodyHtml = $this->getRenderedBodyHtml($template, $context);
+        $bodyText = $this->getRenderedBodyText($template, $context);
 
         if (!empty( $bodyHtml )) {
 
@@ -67,14 +164,14 @@ class ExtraMailer
                 ),
                 'text/html'
             )->addPart(
-                $layoutTxt->render(
-                    array(
-                        'subject'   => $subject,
-                        'body_text' => $bodyText
-                    )
-                ),
-                'text/plain'
-            );
+                    $layoutTxt->render(
+                        array(
+                            'subject'   => $subject,
+                            'body_text' => $bodyText
+                        )
+                    ),
+                    'text/plain'
+                );
         } else {
             $message->setBody(
                 $layoutTxt->render(
@@ -86,14 +183,54 @@ class ExtraMailer
             );
         }
 
-        if (isset($options['attachments'] )) {
-            foreach ($options['attachments'] as $fileName => $attachmentWebPath) {
-                $message->attach(\Swift_Attachment::fromPath($attachmentWebPath)->setFilename($fileName));
-            }
+        return $message;
+    }
+
+    /**
+     * @param \Swift_Message $message
+     * @param array          $attachments
+     *
+     * @return \Swift_Message
+     */
+    public function attach(\Swift_Message $message, array $attachments)
+    {
+        foreach ($attachments as $fileName => $attachmentWebPath) {
+            $message->attach(\Swift_Attachment::fromPath($attachmentWebPath)->setFilename($fileName));
         }
 
-        $this->mailer->send($message);
+        return $message;
+    }
 
-        return true;
+    /**
+     * @param       $template
+     * @param array $context
+     *
+     * @return mixed
+     */
+    public function getRenderedSubject($template, array $context)
+    {
+        return $template->renderBlock('subject', $context);
+    }
+
+    /**
+     * @param       $template
+     * @param array $context
+     *
+     * @return mixed
+     */
+    public function getRenderedBodyText($template, array $context)
+    {
+        return $template->renderBlock('body_text', $context);
+    }
+
+    /**
+     * @param       $template
+     * @param array $context
+     *
+     * @return mixed
+     */
+    public function getRenderedBodyHtml($template, array $context)
+    {
+        return $template->renderBlock('body_html', $context);
     }
 }

--- a/Tests/ExtraMailerTest.php
+++ b/Tests/ExtraMailerTest.php
@@ -40,7 +40,7 @@ class ExtraMailerTest extends \PHPUnit_Framework_TestCase
             'demo' => file_get_contents(
                 __DIR__ . '/../Resources/views/Demo/sample.email.twig'
             ),
-            'demoTXT' => '{% block subject %}Sample subject, email send by EEExtraMailer{% endblock %}{% block body_text %}This is sample email send by EEExtraMailer{% endblock %}'
+            'demoTXT' => '{% block subject %}Sample subject for {{name}} in email sent by EEExtraMailer{% endblock %}{% block body_text %}Hi {{ name }}, This is sample email sent by EEExtraMailer{% endblock %}{% block body_html %}<p>Hi {{ name }}, This is sample email sent by EEExtraMailer</p>{% endblock %}'
         );
 
         $this->twig = $this->getMock('Twig_Environment', null, array(new \Twig_Loader_Array($this->templates)));
@@ -50,7 +50,7 @@ class ExtraMailerTest extends \PHPUnit_Framework_TestCase
     public function testSendMessage()
     {
         $extraMailer = new ExtraMailer($this->container, $this->swift, $this->twig);
-        $this->swift->expects($this->once())->method('send')->will($this->returnValue(0));
+        $this->swift->expects($this->once())->method('send')->will($this->returnValue(1));
         $result = $extraMailer->sendMessage(
             array('recipient@example.com' => 'Recipient Name'),
             'demo',
@@ -58,13 +58,13 @@ class ExtraMailerTest extends \PHPUnit_Framework_TestCase
             array('attachments' => array(__DIR__ . '/../Resources/views/Demo/sample.email.twig'))
         );
 
-        $this->assertTrue($result);
+        $this->assertEquals(1, $result);
     }
 
     public function testSendMessageTxt()
     {
         $extraMailer = new ExtraMailer($this->container, $this->swift, $this->twig);
-        $this->swift->expects($this->once())->method('send')->will($this->returnValue(0));
+        $this->swift->expects($this->once())->method('send')->will($this->returnValue(1));
         $result = $extraMailer->sendMessage(
             array('recipient@example.com' => 'Recipient Name'),
             'demoTXT',
@@ -72,6 +72,108 @@ class ExtraMailerTest extends \PHPUnit_Framework_TestCase
             array('attachments' => array(__DIR__ . '/../Resources/views/Demo/sample.email.twig'))
         );
 
-        $this->assertTrue($result);
+        $this->assertEquals(1, $result);
+    }
+
+
+    public function testSendMessageToManyWithCommonContext()
+    {
+        $extraMailer = new ExtraMailer($this->container, $this->swift, $this->twig);
+
+        $recipients = array(
+            'somename@example.com' => 'Somename',
+            'someothername@example.com' => 'Someothername'
+        );
+
+        $this->swift
+            ->expects($this->once())
+            ->method('send')
+            ->will($this->returnValue(count($recipients)));
+
+
+        $result = $extraMailer->sendMessage(
+            $recipients,
+            'demo',
+            array('name' => 'lol'),
+            array('attachments' => array(__DIR__ . '/../Resources/views/Demo/sample.email.twig'))
+        );
+
+        $this->assertEquals(count($recipients), $result);
+    }
+
+    public function testPrepareMessagesToManyWithSeparateContexts()
+    {
+        $extraMailer = new ExtraMailer($this->container, $this->swift, $this->twig);
+
+        $recipients = array(
+            'somename@example.com' => 'Somename',
+            'someothername@example.com' => 'Someothername'
+        );
+        $contexts = array(
+            array('name' => 'Example Name 1'),
+            array('name' => 'Example Name 2')
+        );
+
+        $messagesArray = $extraMailer->composeMessages(
+            $recipients,
+            'demoTXT',
+            $contexts
+        );
+
+        $expectedSubjectsArray = array(
+            'Sample subject for Example Name 1 in email sent by EEExtraMailer',
+            'Sample subject for Example Name 2 in email sent by EEExtraMailer'
+        );
+
+        for ($i = 0; $i< count($contexts); $i++) {
+            $this->assertEquals(
+                $expectedSubjectsArray[$i],
+                $messagesArray[$i]->getSubject()
+            );
+        }
+
+    }
+
+    public function testGetRenderedSubject()
+    {
+        $extraMailer = new ExtraMailer($this->container, $this->swift, $this->twig);
+
+        $template = $this->twig->loadTemplate('demoTXT');
+
+
+        $subject = $extraMailer->getRenderedSubject($template, array('name' => 'abcdef'));
+
+        $expected = 'Sample subject for abcdef in email sent by EEExtraMailer';
+
+        $this->assertEquals($expected, $subject);
+    }
+
+
+    public function testGetRenderedBodyText()
+    {
+        $extraMailer = new ExtraMailer($this->container, $this->swift, $this->twig);
+
+        $template = $this->twig->loadTemplate('demoTXT');
+
+
+        $subject = $extraMailer->getRenderedBodyText($template, array('name' => 'abcdef'));
+
+        $expected = 'Hi abcdef, This is sample email sent by EEExtraMailer';
+
+        $this->assertEquals($expected, $subject);
+    }
+
+    public function testGetRenderedBodyHtml()
+    {
+        $extraMailer = new ExtraMailer($this->container, $this->swift, $this->twig);
+
+        $template = $this->twig->loadTemplate('demoTXT');
+
+
+        $subject = $extraMailer->getRenderedBodyHtml($template, array('name' => 'abcdef'));
+
+        $expected = '<p>Hi abcdef, This is sample email sent by EEExtraMailer</p>';
+
+        $this->assertEquals($expected, $subject);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
             "email": "konrad.podgorski@gmail.com",
             "homepage": "http://konradpodgorski.com",
             "role": "Developer"
+        },
+        {
+            "name": "Jarek Rencz",
+            "email": "jaroslaw@rencz.pl",
+            "role": "Developer"
         }
     ],
     "minimum-stability": "dev",
@@ -22,7 +27,8 @@
     },
     "require-dev": {
         "symfony/yaml": ">=2.0,<2.4-dev",
-        "symfony/dependency-injection": ">=2.0,<2.4-dev"
+        "symfony/dependency-injection": ">=2.0,<2.4-dev",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": { "EE\\ExtraMailerBundle": "" }


### PR DESCRIPTION
If many recipients are passed to sendMessage() there should be a possibility to choose if all of them get the message with identical variables passed in 3rd parameter ($context) or if each recipient should get tailored message
